### PR TITLE
Added `-E` flag to sed so it uses extended regular expressions

### DIFF
--- a/flake-lang/flake-rust.nix
+++ b/flake-lang/flake-rust.nix
@@ -48,7 +48,7 @@ let
           mkdir $out
           cp -r $src/* $out
           cd $out
-          sed -i 's/${pkgs.lib.escapeRegex extraSourcesDir}/../g' Cargo.toml
+          sed -Ei 's/${pkgs.lib.escapeRegex extraSourcesDir}/../g' Cargo.toml
         '';
       };
 


### PR DESCRIPTION
Nix uses [extended regular expressions](https://nixos.org/manual/nix/stable/language/builtins.html#builtins-match), and when pass the regex to `sed`, we pass an escaped extended regular expression.

So, we probably intended `sed` to also use extended regular expressions instead of the default basic regular expression.

Minimal examples to play with:
- Let's say we have a file named `a+`.  
- Then, `pkgs.lib.escapeRegex ''a+''` produces the string `a\+` (run something like `builtins.trace (lib.escapeRegex ''a+'')  null`
- Now, note that
  ```
  $ echo "aa" | sed  's/a\+/b/g' # this matches, but it shouldn't
  b
  $ echo "aa" | sed -E 's/a\+/b/g' # this doesn't match which is what we want.
  aa
  ```