### PR TITLE
Fix nativeBuildInputs and testTools for Rust

### DIFF
--- a/flake-lang/flake-rust.nix
+++ b/flake-lang/flake-rust.nix
@@ -113,7 +113,7 @@ in
   checks = {
     "${crateName}-rust-test" = craneLib.cargoNextest (commonArgs // {
       inherit cargoArtifacts;
-      nativeBuildInputs = testTools;
+      nativeBuildInputs = testTools ++ nativeBuildInputs;
     });
 
     "${crateName}-rust-clippy" = craneLib.cargoClippy (commonArgs // {

--- a/flake-lang/flake-rust.nix
+++ b/flake-lang/flake-rust.nix
@@ -90,7 +90,7 @@ in
 {
   devShells."dev-${crateName}-rust" = craneLib.devShell {
     buildInputs = nativeBuildInputs;
-    packages = devShellTools;
+    packages = devShellTools ++ testTools;
     shellHook = ''
       ${linkExtraSources}
       ${linkData}


### PR DESCRIPTION
- Adding `nativeBuildInputs` to rust checks (was overwritten by testTools)
- Adding `testTools` to dev shell
