### PR TITLE
rustFlake extraSourceFilters + updating deprecated behaviour

### DIFF
--- a/examples/rust-flake-project-with-extra-dependency/Cargo.toml
+++ b/examples/rust-flake-project-with-extra-dependency/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rust-flake-project = { path = ".extras/rust-flake-project-0.1.0" }
+rust-flake-project = { path = ".extras/rust-flake-project-v0" }

--- a/examples/rust-flake-project-with-extra-dependency/build.nix
+++ b/examples/rust-flake-project-with-extra-dependency/build.nix
@@ -13,6 +13,11 @@
 
           devShellHook = config.settings.shell.hook;
 
+          extraSourceFilters = [
+            # Include Markdown files in sources
+            (path: _type: builtins.match ".*md$" path != null)
+          ];
+
         };
     in
     {

--- a/flake-lang/flake-rust.nix
+++ b/flake-lang/flake-rust.nix
@@ -1,9 +1,10 @@
 inputCrane: pkgs:
 
 { src
+, extraSourceFilters ? [ ]
 , crane ? null
 , crateName
-, version ? "0.1.0"
+, version ? "v0"
 , rustProfile ? "stable"
 , rustVersion ? "latest"
 , nativeBuildInputs ? [ ]
@@ -43,7 +44,19 @@ let
     in
     crane'.lib.${pkgs.system}.overrideToolchain rustWithTools;
 
-  cleanSrc = craneLib.cleanCargoSource (craneLib.path src);
+  cleanSrc =
+    let
+      filter = path: type:
+        pkgs.lib.foldr
+          (filterFn: result: result || filterFn path type)
+          (craneLib.filterCargoSources path type)
+          extraSourceFilters;
+
+    in
+    pkgs.lib.cleanSourceWith {
+      inherit src filter;
+      name = "source"; # Be reproducible, regardless of the directory name
+    };
 
   # Library source code with extra dependencies copied
   buildEnv =

--- a/flake-lang/flake-rust.nix
+++ b/flake-lang/flake-rust.nix
@@ -42,7 +42,7 @@ let
           pkgs.lib.showWarnings [ ''rustFlake: You're setting the `crane` argument which is deprecated and will be removed in the next major revision'' ] crane;
 
     in
-    crane'.lib.${pkgs.system}.overrideToolchain rustWithTools;
+    (crane'.mkLib pkgs).overrideToolchain rustWithTools;
 
   cleanSrc =
     let
@@ -55,7 +55,7 @@ let
     in
     pkgs.lib.cleanSourceWith {
       inherit src filter;
-      name = "source"; # Be reproducible, regardless of the directory name
+      name = "source";
     };
 
   # Library source code with extra dependencies copied


### PR DESCRIPTION
- **Add extraSourceFilters to rust flake**
- **flake-rust: Remove deprecated craneLib import**
