### PR TITLE
Make rustdoc optional

### DIFF
--- a/flake-lang/rust/description.md
+++ b/flake-lang/rust/description.md
@@ -30,6 +30,7 @@ Creates a flake for a Rust project.
 - `extraRustcFlags`(optional): Extra rustc flags
 - `extraCargoArgs`(optional): Extra cargo arguments
 - `extraEnvVars`(optional): Extra environment variables
+- `generateDocs`(default=true): Generate Rustdoc
 
 **Returns:**
 

--- a/flake-lang/rust/flake-rust.nix
+++ b/flake-lang/rust/flake-rust.nix
@@ -45,6 +45,8 @@ inputCrane: pkgs:
   extraCargoArgs ? null
 , # Extra environment variables
   extraEnvVars ? null
+  # Generate Rustdoc
+, generateDocs ? true
 }:
 
 let
@@ -193,18 +195,20 @@ in
     '';
   };
 
-  packages = {
+  packages = (pkgs.lib.optionalAttrs generateDocs {
+    "${crateName}-rust-doc" = craneLib.cargoDoc (commonArgs // {
+      inherit cargoArtifacts;
+      doCheck = false;
+      inherit doInstallCargoArtifacts;
+    });
+
+  }) // {
     "${crateName}-rust" = craneLib.buildPackage (commonArgs // {
       inherit cargoArtifacts;
       doCheck = false;
       inherit doInstallCargoArtifacts;
     });
 
-    "${crateName}-rust-doc" = craneLib.cargoDoc (commonArgs // {
-      inherit cargoArtifacts;
-      doCheck = false;
-      inherit doInstallCargoArtifacts;
-    });
 
     "${crateName}-rust-src" = vendoredSrc;
 


### PR DESCRIPTION
Due to a bug, generating rustdoc for proc-macro libraries fails:
https://github.com/ipetkov/crane/issues/707
